### PR TITLE
I think I fixed this damn shit! This was freaking hardpython3.7 super…

### DIFF
--- a/mediator.py
+++ b/mediator.py
@@ -74,6 +74,7 @@ def mediator(args,input_list,node_object,auditcreeper,output,with_remediation):
 			input_list = get_sorted_juniper_template_list(input_list)
 			rendered_config.append('load replace terminal')
 		for template in input_list:
+			print(node_object[index]['name'],template)
 			"""
 				Uncomment the secrets below if you are using hashicorp vault. You will need to setup the credentials.
 			"""
@@ -115,8 +116,10 @@ def mediator(args,input_list,node_object,auditcreeper,output,with_remediation):
 			against multiple templates. If only one template is being 
 			audited, do no pop off element.
 		"""
-		if len(input_list) != 1:
-			input_list = get_updated_list(template_list_copy)
+#		if len(input_list) != 1:
+		print('template_list_copy > {}'.format(template_list_copy))
+		print('input_list > {}'.format(input_list))
+		input_list = get_updated_list(template_list_copy)
 		if node_object[index]['hardware_vendor'] == 'cisco' or node_object[index]['hardware_vendor'] == 'f5' or node_object[index]['hardware_vendor'] == 'palo_alto':
 			redirect.append('get_config')
 			command.append([''])
@@ -164,6 +167,8 @@ def mediator(args,input_list,node_object,auditcreeper,output,with_remediation):
 			print ("{}".format(node_object[index]['name']))
 		if node_object[index]['hardware_vendor'] == 'cisco' or node_object[index]['hardware_vendor'] == 'f5' or node_object[index]['hardware_vendor'] == 'palo_alto':
 			generic_audit_diff(args,node_configs,node_object,index,template,input_list,AUDIT_FILTER_RE,output,with_remediation)
+			print('node_configs > {}'.format(node_configs))
+			initialize.configuration.append(node_configs)
 		elif node_object[index]['hardware_vendor'] == 'juniper':
 			input_list = get_sorted_juniper_template_list(input_list)
 			directory = get_template_directory(node_object[index]['hardware_vendor'],node_object[index]['opersys'],node_object[index]['type'])
@@ -184,11 +189,12 @@ def mediator(args,input_list,node_object,auditcreeper,output,with_remediation):
 			else:
 				juniper_mediator(node_object,input_list,diff_config,edit_list,index)
 				juniper_audit_diff(directory,input_list,diff_config,edit_list)
-		initialize.configuration.append(node_configs)
+			initialize.configuration.append(rendered_config)
+		print('initialize.configuration > {}'.format(initialize.configuration))
 		if auditcreeper:
-			if len(node_configs) == 0:
-				initialize.ntw_device.pop(node_index)
-				initialize.configuration.pop(node_index)
+			if node_object[index]['hardware_vendor'] == 'cisco' and len(node_configs) == 0:
+				initialize.ntw_device.pop(len(initialize.configuration) - 1)
+				initialize.configuration.pop(len(initialize.configuration) - 1)
 			input_list = get_updated_list(template_list_original)
 
 	return None

--- a/push_cfgs.py
+++ b/push_cfgs.py
@@ -94,14 +94,14 @@ def push_cfgs(args):
 		print('')
 	else:
 		node_create(match_node,node_object)
-		for index in initialize.element:
-			if node_object[index]['hardware_vendor'] == 'cisco' or node_object[index]['hardware_vendor'] == 'citrix':
-				get_diff = True
-				break
-		if get_diff:
-			mediator(args,template_list,node_object,auditcreeper,output,with_remediation)	
-		else:
-			render(template_list,node_object,auditcreeper,output,with_remediation)
+#		for index in initialize.element:
+#			if node_object[index]['hardware_vendor'] == 'cisco' or node_object[index]['hardware_vendor'] == 'citrix':
+#				get_diff = True
+#				break
+#		if get_diff:
+		mediator(args,template_list,node_object,auditcreeper,output,with_remediation)	
+#		else:
+#			render(template_list,node_object,auditcreeper,output,with_remediation)
 		for index in initialize.element:
 			redirect.append('push_cfgs')
 		if not any(initialize.configuration):


### PR DESCRIPTION
I think I fixed this damn shit! This was freaking hard!! push cfgs without the --file flag (ALL templates) works as expected now!


```
root@devvm:~/superloop# python3.7 superloop.py audit diff --node core.* 
core.sw.superloop.ktch base.jinja2
core.sw.superloop.ktch logging.jinja2
core.sw.superloop.ktch service.jinja2
core.sw.superloop.ktch dhcp.jinja2
core.sw.superloop.ktch snmp.jinja2
core.sw.superloop.ktch interfaces.jinja2
template_list_copy > [['base.jinja2', 'logging.jinja2', 'service.jinja2', 'dhcp.jinja2', 'snmp.jinja2', 'interfaces.jinja2'], ['base.jinja2', 'object-groups.jinja2', 'logging.jinja2'], ['routing-instances.jinja2', 'routing-options.jinja2', 'system.jinja2', 'interfaces.jinja2', 'protocols.jinja2']]
input_list > ['base.jinja2', 'logging.jinja2', 'service.jinja2', 'dhcp.jinja2', 'snmp.jinja2', 'interfaces.jinja2']
core-fw-superloop-ktch base.jinja2
core-fw-superloop-ktch object-groups.jinja2
core-fw-superloop-ktch logging.jinja2
template_list_copy > [['base.jinja2', 'object-groups.jinja2', 'logging.jinja2'], ['routing-instances.jinja2', 'routing-options.jinja2', 'system.jinja2', 'interfaces.jinja2', 'protocols.jinja2']]
input_list > ['base.jinja2', 'object-groups.jinja2', 'logging.jinja2']
core.vsrx.superloop.ktch system.jinja2
core.vsrx.superloop.ktch interfaces.jinja2
core.vsrx.superloop.ktch routing-options.jinja2
core.vsrx.superloop.ktch protocols.jinja2
core.vsrx.superloop.ktch routing-instances.jinja2
template_list_copy > [['routing-instances.jinja2', 'routing-options.jinja2', 'system.jinja2', 'interfaces.jinja2', 'protocols.jinja2']]
input_list > ['system.jinja2', 'interfaces.jinja2', 'routing-options.jinja2', 'protocols.jinja2', 'routing-instances.jinja2']
Password: 
+ complete [0:05:52.994811]

Only in the device: -
Only in the generated config: +
core.sw.superloop.ktch
/root/superloop_code/templates/hardware_vendors/cisco/ios/switch/base.jinja2 (none)

/root/superloop_code/templates/hardware_vendors/cisco/ios/switch/logging.jinja2
- logging console emergencies
/root/superloop_code/templates/hardware_vendors/cisco/ios/switch/service.jinja2 (none)

/root/superloop_code/templates/hardware_vendors/cisco/ios/switch/dhcp.jinja2 (none)

/root/superloop_code/templates/hardware_vendors/cisco/ios/switch/snmp.jinja2 (none)

/root/superloop_code/templates/hardware_vendors/cisco/ios/switch/interfaces.jinja2
  interface GigabitEthernet1/0/21
-  shutdown
  interface GigabitEthernet1/0/28
-  switchport mode access
  interface GigabitEthernet1/0/28
+  switchport access vlan 50
node_configs > []
initialize.configuration > [[]]
Only in the device: -
Only in the generated config: +
core-fw-superloop-ktch
/root/superloop_code/templates/hardware_vendors/cisco/asa/firewall/base.jinja2 (none)

/root/superloop_code/templates/hardware_vendors/cisco/asa/firewall/object-groups.jinja2
- object-group network WOODSTOCK-NETWORKS
-  network-object 10.150.50.0 255.255.255.0
  object-group network KITCHENER-NETWORKS
+  network-object 10.50.70.0 255.255.255.248
/root/superloop_code/templates/hardware_vendors/cisco/asa/firewall/logging.jinja2 (none)

node_configs > []
initialize.configuration > [[]]
Only in the device: -
Only in the generated config: +
core.vsrx.superloop.ktch
/root/superloop_code/templates/hardware_vendors/juniper/junos/vfirewall/system.jinja2
[edit system]
-  host-name core.vsrx.superloop.ktch;
+  host-name core.wsrx.superloop.ktch;
-  ntp {
-      server 10.50.30.3;
-  }

/root/superloop_code/templates/hardware_vendors/juniper/junos/vfirewall/interfaces.jinja2
[edit interfaces ge-0/0/0]
-   description test;
[edit interfaces ge-0/0/0 unit 0 family inet]
+       filter {
+           input edge_inbound_softlayer;
+           output edge_outbound_softlayer;
+       }
+       sampling {
+           input;
+       }
[edit interfaces ge-0/0/0 unit 0 family inet]
+       address 10.50.30.10/32;
-       address 10.50.30.10/24;
[edit interfaces]
-   ge-0/0/1 {
-       unit 0 {
-           family inet {
-               address 10.50.40.10/24;
-           }
-       }
-   }

/root/superloop_code/templates/hardware_vendors/juniper/junos/vfirewall/routing-options.jinja2
[edit routing-options static]
+    route 206.198.150.0/23 discard;
+    route 169.254.156.58/32 next-hop 169.63.91.1;
+    route 169.254.156.59/32 next-hop 169.63.91.1;
+    route 10.0.0.0/8 next-hop 10.136.0.1;
[edit routing-options static route 0.0.0.0/0]
-    next-hop 10.50.30.1;
+    next-hop 169.63.91.1;
+    preference 175;
[edit routing-options]
-  router-id 10.50.30.10;
+  router-id 169.63.91.4;
-  autonomous-system 20;
+  autonomous-system 46160;

/root/superloop_code/templates/hardware_vendors/juniper/junos/vfirewall/protocols.jinja2
[edit protocols bgp]
+    group ibgp {
+        type internal;
+        local-address 184.170.238.33;
+        advertise-external;
+        family inet {
+            unicast {
+                loops 5;
+            }
+        }
+        peer-as 46160;
+        neighbor 184.170.238.34;
+    }
+    group softlayer-wdc1-bgp {
+        multihop {
+            ttl 2;
+        }
+        local-address 169.47.1.112;
+        import import_softlayer_wdc1;
+        family inet {
+            unicast {
+                loops 5;
+            }
+        }
+        export export_skytap_network_softlayer_wdc1;
+        remove-private;
+        peer-as 36351;
+        neighbor 169.254.165.202;
+        neighbor 169.254.165.203;
+    }
-    group external-peers {
-        neighbor 10.50.30.1 {
-            peer-as 10;
-        }
-    }
[edit protocols ospf]
+   external-preference 120;
+   export export_softlayer_default;
[edit protocols ospf area 0.0.0.0 interface ge-0/0/0.0]
-     priority 100;
+     priority 250;
+     hello-interval 2;
[edit protocols ospf area 0.0.0.0]
      interface ge-0/0/0.0 { ... }
+     interface ge-0/0/2.0 {
+         passive;
+     }
      interface ge-0/0/1.0 { ... }
[edit protocols ospf area 0.0.0.0 interface ge-0/0/1.0]
+      passive;

/root/superloop_code/templates/hardware_vendors/juniper/junos/vfirewall/routing-instances.jinja2
+  routing-instances {
+      inside {
+          routing-options {
+              static {
+                  defaults {
+                      preference 250;
+                  }
+              }
+          }
+      }
+  }

initialize.configuration > [['load replace terminal', 'replace: system {', '    host-name core.wsrx.superloop.ktch;', '    root-authentication {', '        encrypted-password "$1$kLiqCBwn$2PahfS9RbSbRlQrb6js5e/"; ## SECRET-DATA', '    }', '    name-server {', '        8.8.8.8;', '        172.16.2.3;', '    }', '    login {', '        user admin {', '            uid 2000;', '            class super-user;', '            authentication {', '                encrypted-password "$1$DU8QIMQD$XCI5uxtvrk9.sbNQGIeZa."; ## SECRET-DATA', '            }', '        }', '    }', '    services {', '        ssh;', '        web-management {', '            http {', '                interface ge-0/0/0.0;', '            }', '        }', '    }', '    syslog {', '        user * {', '            any emergency;', '        }', '        file messages {', '            any any;', '            authorization info;', '        }', '        file interactive-commands {', '            interactive-commands any;', '        }', '    }', '}', 'replace: interfaces {', '    ge-0/0/0 {', '        unit 0 {', '            family inet {', '                filter {', '                        input edge_inbound_softlayer;', '                        output edge_outbound_softlayer;', '                    }', '                    sampling {', '                        input;', '                    }', '                address 10.50.30.10;', '            }', '        }', '    }', ' ', '}', 'replace: routing-options {', '    static {', '        route 206.198.150.0/23 discard;', '        route 169.254.156.58/32 next-hop 169.63.91.1;', '        route 169.254.156.59/32 next-hop 169.63.91.1;', '        route 10.0.0.0/8 next-hop 10.136.0.1;', '        route 0.0.0.0/0 {', '            next-hop 169.63.91.1;', '            preference 175;', '        }', '    }', '    router-id 169.63.91.4;', '    autonomous-system 46160;', '}', 'replace: protocols {', '    bgp {', '        group ibgp {', '            type internal;', '            local-address 184.170.238.33;', '            advertise-external;', '            family inet {', '                unicast {', '                    loops 5;', '                }', '            }', '            peer-as 46160;', '            neighbor 184.170.238.34;', '        }', '        group softlayer-wdc1-bgp {', '            multihop {', '                ttl 2;', '            }', '            local-address 169.47.1.112;', '            import import_softlayer_wdc1;', '            family inet {', '                unicast {', '                    loops 5;', '                }', '            }', '            export export_skytap_network_softlayer_wdc1;', '            remove-private;', '            peer-as 36351;', '            neighbor 169.254.165.202;', '            neighbor 169.254.165.203;   ', '        }', '    }', '    ospf {', '        external-preference 120;', '        export export_softlayer_default;', '        area 0.0.0.0 {', '            interface ge-0/0/0.0 {', '                priority 250;', '                hello-interval 2;', '            }', '            interface ge-0/0/2.0 {', '                passive;', '            }', '            interface ge-0/0/1.0 {', '                passive;', '            }', '        }', '    }', '}', 'replace: routing-instances {   ', '    inside {', '        routing-options {', '            static {', '                defaults {', '                    preference 250;', '                }', '            }', '        } ', '     }', '}', '\x04', 'show | compare', 'rollback 0']]
```