### PR TITLE
Improved the look on the output. DEBUG is now displayed in json format.

### DIFF
--- a/confirm.py
+++ b/confirm.py
@@ -8,7 +8,11 @@ from multithread import multithread_engine
 def confirm(redirect,commands,authentication):
 	index = 0
 	if(redirect[index] == 'push_cfgs'):
-		check = str(input("Push configs? [y/N]: ")).strip()
+		try:
+			check = str(input("Push configs? [y/N]: ")).strip()
+		except KeyboardInterrupt as error:
+			print('[>] Terminating...')
+			exit()
 	else:
 		check = str(input("Pull configs? [y/N]: ")).strip()
 	try:

--- a/mediator.py
+++ b/mediator.py
@@ -195,6 +195,7 @@ def mediator(args,input_list,node_object,auditcreeper,output,with_remediation):
 		if auditcreeper:
 			if node_object[index]['hardware_vendor'] == 'cisco' and len(node_configs) == 0:
 				initialize.ntw_device.pop(len(initialize.configuration) - 1)
+				initialize.element.pop(len(initialize.configuration) - 1)
 				initialize.configuration.pop(len(initialize.configuration) - 1)
 			input_list = get_updated_list(template_list_original)
 

--- a/multithread.py
+++ b/multithread.py
@@ -33,7 +33,7 @@ def multithread_engine(ntw_object,redirect,commands,authentication):
 	for some_thread in threading.enumerate():
 		if some_thread != main_thread:
 			some_thread.join()
-	print('+ complete [{}]\n'.format(datetime.datetime.now() - start_time))
+	print('[>] complete [{}]\n'.format(datetime.datetime.now() - start_time))
 
 	return None
 

--- a/push_cfgs.py
+++ b/push_cfgs.py
@@ -2,6 +2,7 @@
 	This module controls the push of the templates.
 """
 import initialize
+import json
 import os
 from lib.objects.basenode import BaseNode
 from processdb import process_nodes
@@ -20,6 +21,8 @@ def push_cfgs(args):
 	argument_node = args.node
 	auditcreeper = False
 	commands = initialize.configuration
+	config_counter = 0
+	debug = {}
 	ext = '.jinja2'
 	output = False 
 	redirect = []
@@ -96,21 +99,21 @@ def push_cfgs(args):
 		exit()
 	else:
 		node_create(match_node,node_object)
-#		for index in initialize.element:
-#			if node_object[index]['hardware_vendor'] == 'cisco' or node_object[index]['hardware_vendor'] == 'citrix':
-#				get_diff = True
-#				break
-#		if get_diff:
 		mediator(args,template_list,node_object,auditcreeper,output,with_remediation)	
-#		else:
-#			render(template_list,node_object,auditcreeper,output,with_remediation)
 		for index in initialize.element:
 			redirect.append('push_cfgs')
 		if not any(initialize.configuration):
 			print('[>] There are no diffs to be pushed. All configuration matches template(s).')
 			print('')
 			exit()
-#		print('configurations > {}'.format(initialize.configuration))
+		for index in initialize.element:
+			debug[node_object[index]['name']] = [initialize.configuration[config_counter]]
+			config_counter = config_counter + 1
+		debug_json = json.dumps(debug, indent=4)
+		print('[DEBUG]\n{}'.format(debug_json))
+#		for index in initialize.element:
+#			print('[DEBUG] {{{} : {}}}'.format(node_object[index]['name'],initialize.configuration[config_counter]))
+#			config_counter = config_counter + 1
 		for index in range(len(initialize.element)):
 			if len(initialize.configuration) != 0:
 				push_cfgs = True


### PR DESCRIPTION
```
root@devvm:~/superloop# python3.7 superloop.py push cfgs --node "core.*(sw|fw)"
[x] core.sw.superloop.ktch ; base.jinja2
[x] core.sw.superloop.ktch ; service.jinja2
[x] core.sw.superloop.ktch ; dhcp.jinja2
[x] core.sw.superloop.ktch ; interfaces.jinja2
[x] core-fw-superloop-ktch ; base.jinja2
[x] core-fw-superloop-ktch ; object-groups.jinja2
[>] core.sw.superloop.ktch ; logging.jinja2
[>] core.sw.superloop.ktch ; snmp.jinja2
[>] core-fw-superloop-ktch ; logging.jinja2
Password: 
[>] complete [0:00:10.990710]

[DEBUG]
{
    "core.sw.superloop.ktch": [
        [
            "logging console emergencies",
            "snmp-server blah"
        ]
    ],
    "core-fw-superloop-ktch": [
        [
            "no logging console emergencies"
        ]
    ]
}
Push configs? [y/N]: ^C[>] Terminating...
```